### PR TITLE
Made getInstance method of AppRepo class thread safe

### DIFF
--- a/app/src/main/java/org/rebuildkerala/repo/AppRepo.java
+++ b/app/src/main/java/org/rebuildkerala/repo/AppRepo.java
@@ -28,7 +28,11 @@ public class AppRepo {
 
     public static AppRepo getInstance(Application application) {
         if (repoInstance == null) {
-            repoInstance = new AppRepo(application);
+            synchronized (AppRepo.class) {
+                if (repoInstance == null) {
+                    repoInstance = new AppRepo(application);
+                }
+            }
         }
         return repoInstance;
     }


### PR DESCRIPTION
getInstance method in AppRepo was not thread-safe. Multiple threads can get inside the` if(instance == null)` condition at the same time and the first few threads that enter (while the instance is still null) can create multiple instances. Which breakes the singleton implementation.

Link to the code line [here](https://github.com/Eldhopj/RebuildKeralaAndroid/blob/f7a0fee20d69b4af6fdd39f4d19ebd5958cfb3bf/app/src/main/java/org/rebuildkerala/repo/AppRepo.java#L30)